### PR TITLE
[drain] an additional check for the daemonset kind when draining

### DIFF
--- a/pkg/controller/drain.go
+++ b/pkg/controller/drain.go
@@ -255,7 +255,7 @@ func (o *DrainOptions) daemonsetFilter(pod api.Pod) (bool, *warning, *fatal) {
 	// management resource - including DaemonSet - is not found).
 	// Such pods will be deleted if --force is used.
 	controllerRef := o.getPodController(pod)
-	if controllerRef == nil || controllerRef.Kind != "DaemonSet" {
+	if controllerRef == nil || controllerRef.Kind != "DaemonSet" || (controllerRef.Kind == "DaemonSet" && controllerRef.APIVersion == "apps.kruise.io/v1alpha1") {
 		return true, nil, nil
 	}
 	if !o.IgnoreDaemonsets {


### PR DESCRIPTION
**What this PR does / why we need it**:
It makes MCM drain (instead of ignoring) ingress nginx pods run by the kruise advanced deaemonset controller before terminating a node.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator

```
