### PR TITLE
removing a terminating machine from balancing after some delay

### DIFF
--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -206,8 +206,6 @@ func (c *controller) reconcileClusterMachine(machine *v1alpha1.Machine) error {
 	}
 
 	if machine.DeletionTimestamp != nil {
-		c.setExcludeLBLabel(machine)
-
 		if c.safetyOptions.DrainDelay.Duration != 0 {
 			if machine.DeletionTimestamp.Add(c.safetyOptions.DrainDelay.Duration).After(time.Now()) {
 				klog.Infof("drain delay of %q has not yet passed for machine %q", c.safetyOptions.DrainDelay.Duration.String(), machine.Name)
@@ -215,6 +213,9 @@ func (c *controller) reconcileClusterMachine(machine *v1alpha1.Machine) error {
 				return nil
 			}
 		}
+
+		// removing the machine from balancing
+		c.setExcludeLBLabel(machine)
 
 		// Processing of delete event
 		if err := c.machineDelete(machine, driver); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This pr introduces a delay between starting terminating a node and removing the node from the load balancing (running ensureLoadBalancer) so that when there is a rolling update of a node group, a new node has slightly more time to get ready and start accepting traffic from the load balancer.
Without this delay, a terminating node gets excluded from balancing right after a new node appears in the cluster, but the new node still requires some extra time to start all necessary containers and pass the load balancer's health checks. At this point, some requests may be dropped.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator

```
