### PR TITLE
fix panic in getSecret

### DIFF
--- a/pkg/controller/machine_util.go
+++ b/pkg/controller/machine_util.go
@@ -607,12 +607,12 @@ func (c *controller) getSecretData(machineClassName string, secretRefs ...*v1.Se
 			continue
 		}
 
-		secretRef, err := c.getSecret(secretRef, machineClassName)
+		secret, err := c.getSecret(secretRef, machineClassName)
 		if err != nil {
 			klog.V(2).Infof("Secret reference %s/%s not found", secretRef.Namespace, secretRef.Name)
 			return nil, err
 		}
-		secretData = mergeDataMaps(secretData, secretRef.Data)
+		secretData = mergeDataMaps(secretData, secret.Data)
 	}
 
 	return secretData, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes situation when deleting several nodes mcm crashes with the error "panic: runtime error: invalid memory address or nil pointer dereference"
**Which issue(s) this PR fixes**:
[machine-controller-manager panic after deleting node groups](https://github.com/deckhouse/deckhouse/issues/8240)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator

```
