### PR TITLE
[vsphere] Ensure VM 'config' property exists in GetVMs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #############      builder                                  #############
-FROM eu.gcr.io/gardener-project/3rd/golang:1.20.2 AS builder
+FROM golang:1.23.3 AS builder
 
 WORKDIR /go/src/github.com/gardener/machine-controller-manager
 COPY . .
@@ -7,7 +7,7 @@ COPY . .
 RUN .ci/build
 
 #############      base                                     #############
-FROM eu.gcr.io/gardener-project/3rd/alpine:3.12.1 as base
+FROM alpine:3.21.3 as base
 
 RUN apk add --update bash curl tzdata
 WORKDIR /

--- a/pkg/driver/driver_vsphere.go
+++ b/pkg/driver/driver_vsphere.go
@@ -785,12 +785,21 @@ func (d *VsphereDriver) GetVMs(machineID string) (VMs, error) {
 
 		matchingVMs := intersectMOReferences(vmObjectRefs, clusterNodeIntersection)
 		for _, vmObjectRef := range matchingVMs {
-			vmObject := vmObjectRef.(*object.VirtualMachine)
+			vmObject, ok := vmObjectRef.(*object.VirtualMachine)
+			if !ok {
+				return nil, fmt.Errorf("one of the retrieved object is not a VM")
+			}
+
 			var vmMO mo.VirtualMachine
 			err := vmObject.Properties(ctx, vmObject.Reference(), []string{"config"}, &vmMO)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get config field from VM properties: %s", err)
 			}
+
+			if vmMO.Config == nil {
+				return nil, fmt.Errorf("the 'config' field of the VM is unset")
+			}
+
 			listOfVMs[d.encodeMachineID(vmMO.Config.Uuid)] = vmMO.Config.Name
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Ensure VM `config` property exists in GetVMs. A nil value for the `config` property causes a panic.

**Which issue(s) this PR fixes**:
Fixes https://github.com/deckhouse/deckhouse/issues/10744

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
