### PR TITLE
Add record event about successful draining node

### DIFF
--- a/cmd/machine-controller-manager/app/controllermanager.go
+++ b/cmd/machine-controller-manager/app/controllermanager.go
@@ -357,7 +357,7 @@ func getAvailableResources(clientBuilder corecontroller.ClientBuilder) (map[sche
 func createRecorder(kubeClient *kubernetes.Clientset) record.EventRecorder {
 	machinescheme.AddToScheme(kubescheme.Scheme)
 	eventBroadcaster := record.NewBroadcaster()
-	eventBroadcaster.StartLogging(klog.V(2).Infof)
+	eventBroadcaster.StartLogging(klog.Infof)
 	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: v1core.New(kubeClient.CoreV1().RESTClient()).Events("")})
 	return eventBroadcaster.NewRecorder(kubescheme.Scheme, v1.EventSource{Component: controllerManagerAgentName})
 }

--- a/cmd/machine-controller-manager/app/controllermanager.go
+++ b/cmd/machine-controller-manager/app/controllermanager.go
@@ -299,7 +299,9 @@ func StartControllers(s *options.MCMServer,
 }
 
 // TODO: In general, any controller checking this needs to be dynamic so
-//  users don't have to restart their controller manager if they change the apiserver.
+//
+//	users don't have to restart their controller manager if they change the apiserver.
+//
 // Until we get there, the structure here needs to be exposed for the construction of a proper ControllerContext.
 func getAvailableResources(clientBuilder corecontroller.ClientBuilder) (map[schema.GroupVersionResource]bool, error) {
 	var discoveryClient discovery.DiscoveryInterface
@@ -355,7 +357,7 @@ func getAvailableResources(clientBuilder corecontroller.ClientBuilder) (map[sche
 func createRecorder(kubeClient *kubernetes.Clientset) record.EventRecorder {
 	machinescheme.AddToScheme(kubescheme.Scheme)
 	eventBroadcaster := record.NewBroadcaster()
-	eventBroadcaster.StartLogging(klog.Infof)
+	eventBroadcaster.StartLogging(klog.V(2).Infof)
 	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: v1core.New(kubeClient.CoreV1().RESTClient()).Events("")})
 	return eventBroadcaster.NewRecorder(kubescheme.Scheme, v1.EventSource{Component: controllerManagerAgentName})
 }

--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -798,8 +798,9 @@ func (c *controller) machineDelete(machine *v1alpha1.Machine, driver drivers.Dri
 			if err == nil {
 				// Drain successful
 				klog.V(2).Infof("Drain successful for machine %q. \nBuf:%v \nErrBuf:%v", machine.Name, buf, errBuf)
+				klog.V(2).Infof("Record event about draining %s", machine.Name)
 				c.recorder.Eventf(machine, corev1.EventTypeNormal, "SuccessfulDrainNode", "success draining Machine's node %q", machine.Status.Node)
-
+				klog.V(2).Infof("Event about draining %s recorded", machine.Name)
 			} else if err != nil && forceDeleteMachine {
 				// Drain failed on force deletion
 				klog.Warningf("Drain failed for machine %q. However, since it's a force deletion shall continue deletion of VM. \nBuf:%v \nErrBuf:%v \nErr-Message:%v", machine.Name, buf, errBuf, err)

--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -797,8 +797,7 @@ func (c *controller) machineDelete(machine *v1alpha1.Machine, driver drivers.Dri
 			err = drainOptions.RunDrain()
 			if err == nil {
 				// Drain successful
-				klog.V(2).Infof("Drain successful for machine %q. \nBuf:%v \nErrBuf:%v", machine.Name, buf, errBuf)
-				klog.V(2).Infof("Record event about draining %s", machine.Name)
+				klog.V(2).Infof("Drain successful for machine %q. \nBuf:%v \nErrBuf:%v\nRecord event about draining %s", machine.Name, buf, errBuf, machine.Name)
 				c.recorder.Eventf(machine, corev1.EventTypeNormal, "SuccessfulDrainNode", "success draining Machine's node %q", machine.Status.Node)
 				klog.V(2).Infof("Event about draining %s recorded", machine.Name)
 			} else if err != nil && forceDeleteMachine {

--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -798,6 +798,7 @@ func (c *controller) machineDelete(machine *v1alpha1.Machine, driver drivers.Dri
 			if err == nil {
 				// Drain successful
 				klog.V(2).Infof("Drain successful for machine %q. \nBuf:%v \nErrBuf:%v", machine.Name, buf, errBuf)
+				c.recorder.Eventf(machine, corev1.EventTypeNormal, "SuccessfulDrainNode", "success draining Machine's node %q", machine.Status.Node)
 
 			} else if err != nil && forceDeleteMachine {
 				// Drain failed on force deletion

--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -797,9 +797,8 @@ func (c *controller) machineDelete(machine *v1alpha1.Machine, driver drivers.Dri
 			err = drainOptions.RunDrain()
 			if err == nil {
 				// Drain successful
-				klog.V(2).Infof("Drain successful for machine %q. \nBuf:%v \nErrBuf:%v\nRecord event about draining %s", machine.Name, buf, errBuf, machine.Name)
+				klog.V(2).Infof("Drain successful for machine %q. \nBuf:%v \nErrBuf:%v", machine.Name, buf, errBuf)
 				c.recorder.Eventf(machine, corev1.EventTypeNormal, "SuccessfulDrainNode", "success draining Machine's node %q", machine.Status.Node)
-				klog.V(2).Infof("Event about draining %s recorded", machine.Name)
 			} else if err != nil && forceDeleteMachine {
 				// Drain failed on force deletion
 				klog.Warningf("Drain failed for machine %q. However, since it's a force deletion shall continue deletion of VM. \nBuf:%v \nErrBuf:%v \nErr-Message:%v", machine.Name, buf, errBuf, err)

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -1014,7 +1014,11 @@ func (c *controller) drainNode(deleteMachineRequest *driver.DeleteMachineRequest
 				// Drain successful
 				klog.V(2).Infof("Drain successful for machine %q. \nBuf:%v \nErrBuf:%v", machine.Name, buf, errBuf)
 
+				klog.V(2).Infof("Record event about draining mu %s", machine.Name)
+
 				c.recorder.Eventf(machine, corev1.EventTypeNormal, "SuccessfulDrainNode", "success draining Machine's node %q", machine.Status.Node)
+
+				klog.V(2).Infof("Event about draining mu %s recorded", machine.Name)
 
 				description = fmt.Sprintf("Drain successful. %s", machineutils.InitiateVMDeletion)
 				state = v1alpha1.MachineStateProcessing

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -1012,9 +1012,7 @@ func (c *controller) drainNode(deleteMachineRequest *driver.DeleteMachineRequest
 			err = drainOptions.RunDrain()
 			if err == nil {
 				// Drain successful
-				klog.V(2).Infof("Drain successful for machine %q. \nBuf:%v \nErrBuf:%v", machine.Name, buf, errBuf)
-
-				klog.V(2).Infof("Record event about draining mu %s", machine.Name)
+				klog.V(2).Infof("Drain successful for machine %q. \nBuf:%v \nErrBuf:%v\nRecord event about draining mu %s", machine.Name, buf, errBuf, machine.Name)
 
 				c.recorder.Eventf(machine, corev1.EventTypeNormal, "SuccessfulDrainNode", "success draining Machine's node %q", machine.Status.Node)
 

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -57,7 +57,8 @@ var (
 )
 
 // TODO: use client library instead when it starts to support update retries
-//       see https://github.com/kubernetes/kubernetes/issues/21479
+//
+//	see https://github.com/kubernetes/kubernetes/issues/21479
 type updateMachineFunc func(machine *v1alpha1.Machine) error
 
 /*
@@ -758,8 +759,8 @@ func (c *controller) deleteMachineFinalizers(machine *v1alpha1.Machine) (machine
 }
 
 /*
-	SECTION
-	Helper Functions
+SECTION
+Helper Functions
 */
 func (c *controller) isHealthy(machine *v1alpha1.Machine) bool {
 	numOfConditions := len(machine.Status.Conditions)
@@ -1012,6 +1013,8 @@ func (c *controller) drainNode(deleteMachineRequest *driver.DeleteMachineRequest
 			if err == nil {
 				// Drain successful
 				klog.V(2).Infof("Drain successful for machine %q. \nBuf:%v \nErrBuf:%v", machine.Name, buf, errBuf)
+
+				c.recorder.Eventf(machine, corev1.EventTypeNormal, "SuccessfulDrainNode", "success draining Machine's node %q", machine.Status.Node)
 
 				description = fmt.Sprintf("Drain successful. %s", machineutils.InitiateVMDeletion)
 				state = v1alpha1.MachineStateProcessing

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -1012,11 +1012,9 @@ func (c *controller) drainNode(deleteMachineRequest *driver.DeleteMachineRequest
 			err = drainOptions.RunDrain()
 			if err == nil {
 				// Drain successful
-				klog.V(2).Infof("Drain successful for machine %q. \nBuf:%v \nErrBuf:%v\nRecord event about draining mu %s", machine.Name, buf, errBuf, machine.Name)
+				klog.V(2).Infof("Drain successful for machine %q. \nBuf:%v \nErrBuf:%v", machine.Name, buf, errBuf)
 
 				c.recorder.Eventf(machine, corev1.EventTypeNormal, "SuccessfulDrainNode", "success draining Machine's node %q", machine.Status.Node)
-
-				klog.V(2).Infof("Event about draining mu %s recorded", machine.Name)
 
 				description = fmt.Sprintf("Drain successful. %s", machineutils.InitiateVMDeletion)
 				state = v1alpha1.MachineStateProcessing


### PR DESCRIPTION
**What this PR does / why we need it**:

Cluster API controller record event about successful draining node (https://github.com/kubernetes-sigs/cluster-api/blob/main/internal/controllers/machine/machine_controller.go#L518).
This event improve mcm and cluster-autoscaler observability and this event ca use with automatic e2e for cluster-autoscaler

![image](https://github.com/user-attachments/assets/c850dffa-ec85-4501-8c57-39626ae285a6)


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator

```
